### PR TITLE
depend on wireguard-tools instead of wireguard meta package

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -41,7 +41,7 @@ ram.runtime = "50M"
     [resources.permissions]
 
     [resources.apt]
-    packages = "wireguard"
+    packages = "wireguard-tools"
     packages_from_raw_bash = """
     if dpkg --compare-versions $(uname -r) lt 5.6; then
         echo wireguard-dkms linux-headers-$(uname -r)

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "WireGuard Client"
 description.en = "Connect your server to VPNs as a client"
 description.fr = "Connectez votre serveur à des VPN en tant que client"
 
-version = "1.0.20210914~ynh1"
+version = "1.0.20251029~ynh1"
 
 maintainers = ["tituspijean"]
 


### PR DESCRIPTION
## Problem

 Installing the wireguard meta package on some ARM boards running armbian pulls as a dependency an incompatible kernel and that results in a system that no longer boots.

## Solution

Now that the wireguard module is integrated into the kernel used by Debian (since kernel version 5.5) , we only need to install wireguard-tools. Since bookwork the packages wireguard-dkms and wireguard-modules no longer exists in debian (see https://packages.debian.org/bookworm/wireguard) leaving only wireguard-tools as a dependency of the wireguard meta-package. However on armbian things can go wrong if installing the wireguard meta-package

Solution : replace `packages = "wireguard"` by `packages = "wireguard-tools"` in manifest.toml

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (tested on Odroid M1 running armbian 25.8.1)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
